### PR TITLE
fix(parser): Correctly assign ticketClose from closing event

### DIFF
--- a/app/FxAnalyzer.tsx
+++ b/app/FxAnalyzer.tsx
@@ -799,7 +799,7 @@ function parseFX(input: string) {
         entryAt: matched?.entryAt,
         exitAt: e.at,
         ticketOpen: matched?.ticketOpen,
-        ticketClose: matched?.ticketClose,
+        ticketClose: e.ticket,
       };
 
       // pips 推定（USDJPYは 0.01 = 1pip として100倍）


### PR DESCRIPTION
The build was failing on Render due to a TypeScript type error. The code was attempting to access a `ticketClose` property from a matched `OpenPosition` object, which does not define this property.

The `OpenPosition` type represents the opening trade and only contains details like `ticketOpen`. The closing ticket information should be sourced from the closing event itself.

This commit corrects the logic to assign `ticketClose` from the closing event (`e.ticket`) when creating a `ClosedTrade` instance. This resolves the type error and allows the Next.js build to complete successfully.