### PR TITLE
feat: Integrate OpenAI for AI-powered trade analysis messages

### DIFF
--- a/app/api/generate-ai-message/route.ts
+++ b/app/api/generate-ai-message/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import OpenAI from "openai";
+
+// Initialize OpenAI client
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+// Define the structure of the summary data we expect
+type TradeSummary = {
+  count: number;
+  winRate: number;
+  totalPips: number;
+  avgPips: number;
+  avgHold: string;
+  maxDD: number;
+  totalQtyPL: number;
+  expectancyQty: number;
+  payoff: number;
+};
+
+export async function POST(req: NextRequest) {
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json(
+      { error: "OpenAI API key is not configured on the server." },
+      { status: 500 }
+    );
+  }
+
+  let summary: TradeSummary;
+  try {
+    summary = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const {
+    count,
+    winRate,
+    totalPips,
+    payoff,
+    expectancyQty
+  } = summary;
+
+  // Do not call API if there's no data
+  if (count === 0) {
+    return NextResponse.json({ message: "トレードデータがありません。分析を開始するには、まずログを保存してください。" });
+  }
+
+  const prompt = `
+あなたはプロのFXトレーディングコーチです。以下のトレード分析結果を基に、トレーダーへのアドバイスを日本語で、親しみやすく、かつ的確に150字以内で生成してください。
+
+### トレード分析結果
+- トレード回数: ${count}回
+- 勝率: ${winRate.toFixed(1)}%
+- 合計獲得pips: ${totalPips.toFixed(1)} pips
+- ペイオフレシオ: ${isFinite(payoff) ? payoff.toFixed(2) : "算出不能"}
+- 期待値 (1トレードあたり): ${isFinite(expectancyQty) ? expectancyQty.toFixed(2) : "算出不能"} 円
+
+### 指示
+- 勝率とペイオフレシオの関係性に注目してください。
+- 期待値がプラスかマイナスかを基に、現状のトレードスタイルの評価をしてください。
+- 今後改善すべき点を、具体的かつ簡潔に指摘してください。
+- 全体として、ポジティブでモチベーションが上がるようなトーンでお願いします。
+`;
+
+  try {
+    const response = await openai.chat.completions.create({
+      model: "gpt-4o", // Using the latest powerful model
+      messages: [
+        {
+          role: "system",
+          content: "あなたはプロのFXトレーディングコーチです。親しみやすいトーンで、的確なアドバイスを日本語で提供します。",
+        },
+        { role: "user", content: prompt },
+      ],
+      max_tokens: 250,
+      temperature: 0.7,
+    });
+
+    const message = response.choices[0]?.message?.content?.trim() || "AIからのメッセージ生成に失敗しました。";
+    return NextResponse.json({ message });
+
+  } catch (error) {
+    console.error("Error calling OpenAI API:", error);
+    return NextResponse.json(
+      { error: "Failed to get a response from OpenAI." },
+      { status: 500 }
+    );
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.540.0",
         "next": "^15.5.0",
+        "openai": "^5.15.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1680,6 +1681,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.15.0.tgz",
+      "integrity": "sha512-kcUdws8K/A8m02I+IqFBwO51gS+87GP89yWEufGbzEi8anBz4FB/bti2QxaJdGwwY4mwJGzx85XO7TuL/Tpu1w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.540.0",
     "next": "^15.5.0",
+    "openai": "^5.15.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },


### PR DESCRIPTION
This commit introduces a new feature that replaces the static, rule-based "AIからのメッセージ" with dynamically generated advice from the OpenAI API.

Key changes include:
- A new Next.js API route (`/api/generate-ai-message`) is created to handle server-side communication with the OpenAI API. It takes trade summary data, constructs a detailed prompt, and requests analysis from the `gpt-4o` model.
- The `openai` package is added as a dependency.
- The main frontend component (`FxAnalyzer.tsx`) is refactored to:
  - Manage state for the AI message, including loading and error handling.
  - Call the new API endpoint whenever the trade summary is updated.
  - Display the AI-generated message, or the corresponding loading/error state, in the UI.
- The previous hardcoded message generation logic (`generateAiMessage` function) has been removed.

This provides users with more insightful and dynamic feedback on their trading performance. The feature requires an `OPENAI_API_KEY` to be set in the environment.