### PR TITLE
fix: Defer OpenAI client instantiation to fix build error

### DIFF
--- a/app/api/generate-ai-message/route.ts
+++ b/app/api/generate-ai-message/route.ts
@@ -1,11 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
 
-// Initialize OpenAI client
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
-
 // Define the structure of the summary data we expect
 type TradeSummary = {
   count: number;
@@ -20,12 +15,14 @@ type TradeSummary = {
 };
 
 export async function POST(req: NextRequest) {
-  if (!process.env.OPENAI_API_KEY) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
     return NextResponse.json(
       { error: "OpenAI API key is not configured on the server." },
       { status: 500 }
     );
   }
+  const openai = new OpenAI({ apiKey });
 
   let summary: TradeSummary;
   try {


### PR DESCRIPTION
The Render deployment was failing during the `next build` step with an error indicating that `OPENAI_API_KEY` was missing.

This was caused by the OpenAI client being instantiated at the module's top level in the API route. At build time, environment variables like API keys are not available, causing the constructor to throw an error.

This commit resolves the issue by moving the `new OpenAI(...)` instantiation from the module scope into the `POST` request handler. This defers the client initialization until runtime, when the API route is actually called and the environment variables have been properly loaded.