### PR TITLE
This commit fixes a build error caused by a missing import for the 'T…

### DIFF
--- a/app/FxAnalyzer.tsx
+++ b/app/FxAnalyzer.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
-import { Save, Wand2, FileText, CheckCircle2, AlertTriangle, TrendingUp, Edit, Tag, Trash2 } from "lucide-react";
+import { Save, Wand2, FileText, CheckCircle2, AlertTriangle, TrendingUp, TrendingDown, Edit, Tag, Trash2 } from "lucide-react";
 import AnalysisMenu from "./AnalysisMenu";
 import AnalysisViewer from "./AnalysisViewer";
 import { ClosedTrade, Snapshot } from './types';


### PR DESCRIPTION
…rendingDown' icon from 'lucide-react' in the FxAnalyzer.tsx file.

The icon was being used in a DataTable renderer but was not imported after a previous refactoring, leading to a "Cannot find name 'TrendingDown'" error during the build process. This commit adds the necessary import to resolve the issue.