### PR TITLE
Fix: Add explicit type annotation to fix build error

### DIFF
--- a/app/FxAnalyzer.tsx
+++ b/app/FxAnalyzer.tsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion";
 import { Save, Wand2, FileText, CheckCircle2, AlertTriangle, TrendingUp, TrendingDown, Edit, Tag, Trash2 } from "lucide-react";
 import AnalysisMenu from "./AnalysisMenu";
 import AnalysisViewer from "./AnalysisViewer";
-import { ClosedTrade, Snapshot } from './types';
+import { ClosedTrade, Snapshot, GoalProjection } from './types';
 import { DataTable } from "./DataTable";
 import { Card, Stat } from './shared/components';
 import {
@@ -121,7 +121,7 @@ export default function FXAnalyzer() {
     };
   }, [savedClosed, startBalance, summary.totalQtyPL]);
 
-  const goalProjection = useMemo(() => {
+  const goalProjection = useMemo((): GoalProjection => {
     const currentBalance = startBalance + summary.totalQtyPL;
     if (targetBalance <= currentBalance) return { status: 'achieved', days: 0 };
     if (!longTermProjection || longTermProjection.avgDailyPL <= 0) return { status: 'unreachable', days: Infinity };


### PR DESCRIPTION
The build was failing due to a TypeScript type mismatch. The `goalProjection` constant's `status` property was being inferred as a generic `string`, while the `AnalysisViewer` component expected a specific literal union type ('achieved' | 'unreachable' | 'projected').

This commit fixes the issue by:
1. Importing the `GoalProjection` type in `FxAnalyzer.tsx`.
2. Adding an explicit `: GoalProjection` return type annotation to the `useMemo` hook that calculates `goalProjection`.

This ensures that the type is correctly inferred and matches the prop type expected by the child component, resolving the build failure.