### PR TITLE
Fix: Add missing type definitions to fix build error

### DIFF
--- a/app/types.ts
+++ b/app/types.ts
@@ -51,3 +51,27 @@ export type TagAnalysis = {
     tagName: string;
     summary: Summary;
 };
+
+export type RawBlock = {
+  header: string;
+  lines: string[];
+};
+
+export type Event = {
+  symbol: string;
+  action: '新規' | '決済';
+  side: '買' | '売';
+  size: number;
+  orderPrice?: number;
+  at?: Date;
+  ticket?: string;
+};
+
+export type OpenPosition = {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  size: number;
+  entryPrice?: number;
+  entryAt?: Date;
+  ticketOpen?: string;
+};


### PR DESCRIPTION
The build was failing because the types `RawBlock`, `Event`, and `OpenPosition` were being imported in `app/utils.ts` but were not defined or exported from `app/types.ts`.

This commit fixes the issue by adding the inferred type definitions for `RawBlock`, `Event`, and `OpenPosition` to `app/types.ts`. This resolves the module import error and should allow the build to succeed.